### PR TITLE
Add placeholder pages for dashboard navigation sections

### DIFF
--- a/apps/web/src/app/activos/page.tsx
+++ b/apps/web/src/app/activos/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+
+export default function ActivosPage() {
+  return (
+    <DashboardLayout>
+      <div className="space-y-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Activos</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Consulta y gestiona el inventario de activos críticos de tus clientes.
+          </p>
+        </div>
+        <div className="rounded-lg border border-dashed border-gray-200 bg-white p-6 text-center">
+          <p className="text-sm text-gray-500">
+            El listado de activos y su bitácora estarán disponibles aquí muy pronto.
+          </p>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/apps/web/src/app/clientes/page.tsx
+++ b/apps/web/src/app/clientes/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+
+export default function ClientesPage() {
+  return (
+    <DashboardLayout>
+      <div className="space-y-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Clientes</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Gestiona el listado de clientes, sus ubicaciones y datos de contacto.
+          </p>
+        </div>
+        <div className="rounded-lg border border-dashed border-gray-200 bg-white p-6 text-center">
+          <p className="text-sm text-gray-500">
+            Próximamente podrás crear, importar y administrar clientes desde esta sección.
+          </p>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/apps/web/src/app/configuracion/page.tsx
+++ b/apps/web/src/app/configuracion/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+
+export default function ConfiguracionPage() {
+  return (
+    <DashboardLayout>
+      <div className="space-y-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Configuración</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Ajusta la información corporativa, integraciones y preferencias del sistema.
+          </p>
+        </div>
+        <div className="rounded-lg border border-dashed border-gray-200 bg-white p-6 text-center">
+          <p className="text-sm text-gray-500">
+            Próximamente podrás personalizar la experiencia de tu empresa desde esta configuración avanzada.
+          </p>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/apps/web/src/app/cotizaciones/page.tsx
+++ b/apps/web/src/app/cotizaciones/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+
+export default function CotizacionesPage() {
+  return (
+    <DashboardLayout>
+      <div className="space-y-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Cotizaciones</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Crea, revisa y da seguimiento a las cotizaciones colaborativas de mantenimiento.
+          </p>
+        </div>
+        <div className="rounded-lg border border-dashed border-gray-200 bg-white p-6 text-center">
+          <p className="text-sm text-gray-500">
+            Estamos preparando el flujo colaborativo de cotizaciones. Muy pronto podrás gestionarlas desde aquí.
+          </p>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/apps/web/src/app/documentos/page.tsx
+++ b/apps/web/src/app/documentos/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+
+export default function DocumentosPage() {
+  return (
+    <DashboardLayout>
+      <div className="space-y-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Documentos</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Centraliza las evidencias, certificados y archivos relacionados con las operaciones.
+          </p>
+        </div>
+        <div className="rounded-lg border border-dashed border-gray-200 bg-white p-6 text-center">
+          <p className="text-sm text-gray-500">
+            Estamos construyendo el gestor documental para que puedas almacenar y compartir archivos de forma segura.
+          </p>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/apps/web/src/app/emergencias/page.tsx
+++ b/apps/web/src/app/emergencias/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+
+export default function EmergenciasPage() {
+  return (
+    <DashboardLayout>
+      <div className="space-y-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Emergencias</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Da seguimiento a los incidentes críticos y monitorea el cumplimiento de los SLA.
+          </p>
+        </div>
+        <div className="rounded-lg border border-dashed border-gray-200 bg-white p-6 text-center">
+          <p className="text-sm text-gray-500">
+            Esta vista permitirá coordinar la respuesta y resolver emergencias en el menor tiempo posible.
+          </p>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/apps/web/src/app/mantenimiento/page.tsx
+++ b/apps/web/src/app/mantenimiento/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+
+export default function MantenimientoPage() {
+  return (
+    <DashboardLayout>
+      <div className="space-y-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Mantenimiento</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Planifica y controla los planes de mantenimiento preventivo y correctivo.
+          </p>
+        </div>
+        <div className="rounded-lg border border-dashed border-gray-200 bg-white p-6 text-center">
+          <p className="text-sm text-gray-500">
+            Próximamente podrás crear planes, definir periodicidades y seguir su cumplimiento en esta sección.
+          </p>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/apps/web/src/app/ordenes-trabajo/page.tsx
+++ b/apps/web/src/app/ordenes-trabajo/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+
+export default function OrdenesTrabajoPage() {
+  return (
+    <DashboardLayout>
+      <div className="space-y-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Órdenes de Trabajo</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Supervisa el ciclo de vida de las órdenes de trabajo desde su creación hasta el cierre.
+          </p>
+        </div>
+        <div className="rounded-lg border border-dashed border-gray-200 bg-white p-6 text-center">
+          <p className="text-sm text-gray-500">
+            Aquí podrás asignar técnicos, adjuntar evidencias y monitorear el avance de cada orden.
+          </p>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/apps/web/src/app/reportes/page.tsx
+++ b/apps/web/src/app/reportes/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+
+export default function ReportesPage() {
+  return (
+    <DashboardLayout>
+      <div className="space-y-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Reportes</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Genera reportes operativos y ejecutivos con los indicadores clave de mantenimiento.
+          </p>
+        </div>
+        <div className="rounded-lg border border-dashed border-gray-200 bg-white p-6 text-center">
+          <p className="text-sm text-gray-500">
+            Pronto podrás descargar reportes personalizados y compartirlos con tus clientes desde aquí.
+          </p>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/apps/web/src/app/usuarios/page.tsx
+++ b/apps/web/src/app/usuarios/page.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+
+export default function UsuariosPage() {
+  return (
+    <DashboardLayout>
+      <div className="space-y-4">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Usuarios</h1>
+          <p className="mt-1 text-sm text-gray-600">
+            Administra los miembros del equipo, sus roles y niveles de acceso dentro de la plataforma.
+          </p>
+        </div>
+        <div className="rounded-lg border border-dashed border-gray-200 bg-white p-6 text-center">
+          <p className="text-sm text-gray-500">
+            En breve podrás invitar usuarios, asignar roles y gestionar permisos desde esta sección.
+          </p>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}


### PR DESCRIPTION
## Summary
- add placeholder pages for each navigation entry so the sidebar no longer points to missing routes

## Testing
- npm run dev *(fails: `next` not found because dependencies could not be installed due to npm registry 403)*

------
https://chatgpt.com/codex/tasks/task_b_68d9cb9430a08326b3ce386935c6ed16