### PR TITLE
Add PDF generation for cotizaciones

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -55,6 +55,7 @@
     "multer-s3": "^3.0.1",
     "nodemailer": "^6.9.0",
     "puppeteer": "^21.0.0",
+    "pdfkit": "^0.13.0",
     "handlebars": "^4.7.8",
     "moment": "^2.29.4",
     "uuid": "^9.0.0",

--- a/apps/api/src/cotizaciones/cotizaciones.controller.spec.ts
+++ b/apps/api/src/cotizaciones/cotizaciones.controller.spec.ts
@@ -1,0 +1,38 @@
+import { StreamableFile } from '@nestjs/common';
+import { CotizacionesController } from './cotizaciones.controller';
+import { CotizacionesService } from './cotizaciones.service';
+import { CurrentUserData } from '../auth/decorators/current-user.decorator';
+
+describe('CotizacionesController', () => {
+  let controller: CotizacionesController;
+  let service: { generatePdf: jest.Mock };
+
+  const user: CurrentUserData = {
+    id: 'user-1',
+    username: 'user',
+    email: 'user@example.com',
+    nombre: 'Usuario',
+    apellido: 'Prueba',
+    rol: 'admin',
+    empresaId: 'empresa-1',
+    empresaCodigo: 'EMP-1',
+  };
+
+  beforeEach(() => {
+    service = {
+      generatePdf: jest.fn(),
+    };
+
+    controller = new CotizacionesController(service as unknown as CotizacionesService);
+  });
+
+  it('should delegate PDF generation to the service', async () => {
+    const stream = new StreamableFile(Buffer.from('pdf'));
+    service.generatePdf.mockResolvedValue(stream);
+
+    const result = await controller.downloadPdf('cotizacion-1', user);
+
+    expect(service.generatePdf).toHaveBeenCalledWith('cotizacion-1', user);
+    expect(result).toBe(stream);
+  });
+});

--- a/apps/api/src/cotizaciones/cotizaciones.controller.ts
+++ b/apps/api/src/cotizaciones/cotizaciones.controller.ts
@@ -8,6 +8,7 @@ import {
   Delete,
   UseGuards,
   ParseUUIDPipe,
+  StreamableFile,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { CotizacionesService } from './cotizaciones.service';
@@ -55,7 +56,7 @@ export class CotizacionesController {
   }
 
   @Get(':id')
-  @ApiOperation({ 
+  @ApiOperation({
     summary: 'Obtener cotización por ID',
     description: 'Obtener detalles de una cotización específica. Los técnicos no ven precios.'
   })
@@ -66,6 +67,28 @@ export class CotizacionesController {
     @CurrentUser() user: CurrentUserData,
   ) {
     return this.cotizacionesService.findOne(id, user);
+  }
+
+  @Get(':id/pdf')
+  @ApiOperation({
+    summary: 'Descargar cotización en PDF',
+    description: 'Generar un PDF con el detalle de la cotización',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'PDF generado correctamente',
+    content: {
+      'application/pdf': {
+        schema: { type: 'string', format: 'binary' },
+      },
+    },
+  })
+  @ApiResponse({ status: 404, description: 'Cotización no encontrada' })
+  downloadPdf(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: CurrentUserData,
+  ): Promise<StreamableFile> {
+    return this.cotizacionesService.generatePdf(id, user);
   }
 
   @Patch(':id')

--- a/apps/api/src/cotizaciones/cotizaciones.module.ts
+++ b/apps/api/src/cotizaciones/cotizaciones.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { CotizacionesService } from './cotizaciones.service';
 import { CotizacionesController } from './cotizaciones.controller';
+import { PdfModule } from '../shared/pdf/pdf.module';
 
 @Module({
+  imports: [PdfModule],
   controllers: [CotizacionesController],
   providers: [CotizacionesService],
   exports: [CotizacionesService],

--- a/apps/api/src/cotizaciones/cotizaciones.service.spec.ts
+++ b/apps/api/src/cotizaciones/cotizaciones.service.spec.ts
@@ -1,0 +1,128 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { CotizacionesService } from './cotizaciones.service';
+import { PrismaService } from '../database/prisma.service';
+import { PdfService } from '../shared/pdf/pdf.service';
+import { CurrentUserData } from '../auth/decorators/current-user.decorator';
+
+describe('CotizacionesService - generatePdf', () => {
+  let service: CotizacionesService;
+  let prisma: { cotizacion: { findUnique: jest.Mock } };
+  let pdfService: { createCotizacionPdf: jest.Mock };
+
+  const baseUser: CurrentUserData = {
+    id: 'user-1',
+    username: 'user',
+    email: 'user@example.com',
+    nombre: 'Usuario',
+    apellido: 'Prueba',
+    rol: 'admin',
+    empresaId: 'empresa-1',
+    empresaCodigo: 'EMP-1',
+  };
+
+  const cotizacionRecord = {
+    id: 'cotizacion-1',
+    numero: 'COT-1',
+    empresaId: 'empresa-1',
+    estado: 'borrador',
+    createdAt: new Date('2024-01-01T10:00:00Z'),
+    subtotal: 100,
+    impuestos: 19,
+    total: 119,
+    cliente: { nombre: 'ACME Corp', email: 'contacto@acme.com' },
+    activo: { nombre: 'Motor principal', codigo: 'ACT-1' },
+    items: [
+      {
+        id: 'item-1',
+        descripcion: 'Revisión de motor',
+        cantidad: 2,
+        urgencia: 'alta',
+        precioUnitario: 50,
+        subtotal: 100,
+        createdAt: new Date('2024-01-02T10:00:00Z'),
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    prisma = {
+      cotizacion: {
+        findUnique: jest.fn(),
+      },
+    };
+
+    pdfService = {
+      createCotizacionPdf: jest.fn(),
+    };
+
+    service = new CotizacionesService(
+      prisma as unknown as PrismaService,
+      pdfService as unknown as PdfService,
+    );
+  });
+
+  it('throws NotFoundException when cotizacion does not exist', async () => {
+    prisma.cotizacion.findUnique.mockResolvedValue(null);
+
+    await expect(service.generatePdf('cotizacion-inexistente', baseUser)).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('throws ForbiddenException when user belongs to another company', async () => {
+    prisma.cotizacion.findUnique.mockResolvedValue({ ...cotizacionRecord, empresaId: 'empresa-2' });
+
+    await expect(service.generatePdf('cotizacion-1', baseUser)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+  });
+
+  it('returns a StreamableFile with pricing information for privileged roles', async () => {
+    prisma.cotizacion.findUnique.mockResolvedValue(cotizacionRecord);
+    const pdfBuffer = Buffer.from('%PDF-1.4 test pdf %%EOF', 'utf-8');
+    pdfService.createCotizacionPdf.mockResolvedValue(pdfBuffer);
+
+    const result = await service.generatePdf('cotizacion-1', baseUser);
+
+    expect(pdfService.createCotizacionPdf).toHaveBeenCalledWith(
+      expect.objectContaining({
+        numero: 'COT-1',
+        includePrecios: true,
+        subtotal: cotizacionRecord.subtotal,
+        items: [
+          expect.objectContaining({
+            precioUnitario: cotizacionRecord.items[0].precioUnitario,
+            subtotal: cotizacionRecord.items[0].subtotal,
+          }),
+        ],
+      }),
+    );
+
+    const headers = result.getHeaders();
+    expect(headers['Content-Type']).toBe('application/pdf');
+    expect(headers['Content-Disposition']).toContain('cotizacion-COT-1.pdf');
+  });
+
+  it('omits pricing details when the user is a technician', async () => {
+    prisma.cotizacion.findUnique.mockResolvedValue(cotizacionRecord);
+    const pdfBuffer = Buffer.from('%PDF-1.4 test pdf %%EOF', 'utf-8');
+    pdfService.createCotizacionPdf.mockResolvedValue(pdfBuffer);
+
+    const tecnicoUser: CurrentUserData = {
+      ...baseUser,
+      rol: 'tecnico',
+    };
+
+    await service.generatePdf('cotizacion-1', tecnicoUser);
+
+    expect(pdfService.createCotizacionPdf).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includePrecios: false,
+        subtotal: null,
+        impuestos: null,
+        total: null,
+        items: [expect.objectContaining({ precioUnitario: null, subtotal: null })],
+      }),
+    );
+  });
+});

--- a/apps/api/src/shared/pdf/pdf.module.ts
+++ b/apps/api/src/shared/pdf/pdf.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { PdfService } from './pdf.service';
+
+@Module({
+  providers: [PdfService],
+  exports: [PdfService],
+})
+export class PdfModule {}

--- a/apps/api/src/shared/pdf/pdf.service.spec.ts
+++ b/apps/api/src/shared/pdf/pdf.service.spec.ts
@@ -1,0 +1,33 @@
+import { PdfService } from './pdf.service';
+
+describe('PdfService', () => {
+  const service = new PdfService();
+
+  it('genera un PDF válido para una cotización', async () => {
+    const buffer = await service.createCotizacionPdf({
+      numero: 'COT-1',
+      estado: 'borrador',
+      createdAt: new Date('2024-01-01T10:00:00Z'),
+      cliente: { nombre: 'ACME' },
+      activo: { nombre: 'Motor' },
+      items: [
+        {
+          descripcion: 'Diagnóstico general',
+          cantidad: 1,
+          urgencia: 'media',
+          precioUnitario: 50,
+          subtotal: 50,
+        },
+      ],
+      subtotal: 50,
+      impuestos: 9.5,
+      total: 59.5,
+      includePrecios: true,
+    });
+
+    expect(Buffer.isBuffer(buffer)).toBe(true);
+    expect(buffer.byteLength).toBeGreaterThan(0);
+    expect(buffer.subarray(0, 4).toString()).toBe('%PDF');
+    expect(buffer.includes(Buffer.from('%%EOF'))).toBe(true);
+  });
+});

--- a/apps/api/src/shared/pdf/pdf.service.ts
+++ b/apps/api/src/shared/pdf/pdf.service.ts
@@ -1,0 +1,140 @@
+import { Injectable } from '@nestjs/common';
+
+export interface CotizacionPdfData {
+  numero?: string | null;
+  estado?: string | null;
+  createdAt?: Date | string | null;
+  cliente?: {
+    nombre?: string | null;
+    email?: string | null;
+    telefono?: string | null;
+  } | null;
+  activo?: {
+    nombre?: string | null;
+    codigo?: string | null;
+  } | null;
+  items: Array<{
+    descripcion?: string | null;
+    cantidad?: number | null;
+    urgencia?: string | null;
+    precioUnitario?: number | null;
+    subtotal?: number | null;
+  }>;
+  subtotal?: number | null;
+  impuestos?: number | null;
+  total?: number | null;
+  includePrecios: boolean;
+}
+
+@Injectable()
+export class PdfService {
+  async createCotizacionPdf(data: CotizacionPdfData): Promise<Buffer> {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const PDFDocument = require('pdfkit');
+    const doc = new PDFDocument({ size: 'A4', margin: 50 });
+    const chunks: Buffer[] = [];
+
+    doc.on('data', (chunk: Buffer) => chunks.push(chunk));
+
+    const endPromise = new Promise<void>((resolve) => {
+      doc.on('end', () => resolve());
+    });
+
+    const title = data.numero ? `Cotización ${data.numero}` : 'Cotización';
+    doc.fontSize(20).text(title, { align: 'center' });
+    doc.moveDown();
+
+    doc.fontSize(12);
+    if (data.estado) {
+      doc.text(`Estado: ${this.capitalize(data.estado)}`);
+    }
+
+    if (data.createdAt) {
+      const date = this.formatDate(data.createdAt);
+      doc.text(`Fecha de creación: ${date}`);
+    }
+
+    if (data.cliente) {
+      doc.text(`Cliente: ${data.cliente.nombre ?? 'N/A'}`);
+      if (data.cliente.email) {
+        doc.text(`Email: ${data.cliente.email}`);
+      }
+      if (data.cliente.telefono) {
+        doc.text(`Teléfono: ${data.cliente.telefono}`);
+      }
+    }
+
+    if (data.activo) {
+      doc.text(`Activo: ${data.activo.nombre ?? 'N/A'}`);
+      if (data.activo.codigo) {
+        doc.text(`Código del activo: ${data.activo.codigo}`);
+      }
+    }
+
+    doc.moveDown();
+    doc.fontSize(14).text('Detalle de items', { underline: true });
+    doc.moveDown(0.5);
+
+    if (!data.items.length) {
+      doc.fontSize(12).text('No hay items registrados.');
+    }
+
+    data.items.forEach((item, index) => {
+      doc.fontSize(12).text(`${index + 1}. ${item.descripcion ?? 'Item sin descripción'}`);
+      if (item.cantidad !== undefined && item.cantidad !== null) {
+        doc.fontSize(10).text(`Cantidad: ${item.cantidad}`);
+      }
+      if (item.urgencia) {
+        doc.fontSize(10).text(`Urgencia: ${this.capitalize(item.urgencia)}`);
+      }
+      if (data.includePrecios) {
+        if (item.precioUnitario !== undefined && item.precioUnitario !== null) {
+          doc.fontSize(10).text(`Precio unitario: ${this.formatCurrency(item.precioUnitario)}`);
+        }
+        if (item.subtotal !== undefined && item.subtotal !== null) {
+          doc.fontSize(10).text(`Subtotal: ${this.formatCurrency(item.subtotal)}`);
+        }
+      }
+      doc.moveDown(0.5);
+    });
+
+    if (data.includePrecios) {
+      doc.moveDown();
+      doc.fontSize(14).text('Totales', { underline: true });
+      if (data.subtotal !== undefined && data.subtotal !== null) {
+        doc.fontSize(12).text(`Subtotal: ${this.formatCurrency(data.subtotal)}`);
+      }
+      if (data.impuestos !== undefined && data.impuestos !== null) {
+        doc.fontSize(12).text(`Impuestos: ${this.formatCurrency(data.impuestos)}`);
+      }
+      if (data.total !== undefined && data.total !== null) {
+        doc.fontSize(12).text(`Total: ${this.formatCurrency(data.total)}`);
+      }
+    }
+
+    doc.end();
+    await endPromise;
+
+    return Buffer.concat(chunks);
+  }
+
+  private capitalize(value: string): string {
+    if (!value) {
+      return value;
+    }
+    return value.charAt(0).toUpperCase() + value.slice(1);
+  }
+
+  private formatDate(value: Date | string): string {
+    const date = value instanceof Date ? value : new Date(value);
+    return date.toLocaleDateString('es-ES');
+  }
+
+  private formatCurrency(value: number): string {
+    return new Intl.NumberFormat('es-ES', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 2,
+    }).format(value);
+  }
+}

--- a/apps/api/src/types/pdfkit.d.ts
+++ b/apps/api/src/types/pdfkit.d.ts
@@ -1,0 +1,1 @@
+declare module 'pdfkit';

--- a/apps/web/src/lib/api.spec.ts
+++ b/apps/web/src/lib/api.spec.ts
@@ -1,0 +1,16 @@
+import * as apiModule from './api';
+
+describe('cotizacionesAPI.generatePDF', () => {
+  it('invoca la descarga del PDF con la ruta correcta', async () => {
+    const downloadSpy = jest.spyOn(apiModule.api, 'download').mockResolvedValue();
+
+    await apiModule.cotizacionesAPI.generatePDF('cotizacion-1');
+
+    expect(downloadSpy).toHaveBeenCalledWith(
+      '/cotizaciones/cotizacion-1/pdf',
+      'cotizacion-cotizacion-1.pdf',
+    );
+
+    downloadSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add a `/cotizaciones/:id/pdf` controller action that streams PDFs generated by the service
- integrate a reusable `PdfService` based on pdfkit and expose it through the cotizaciones module
- cover the new flow with backend and frontend unit tests, including PDF buffer validation

## Testing
- npm install *(fails: registry access returns 403)*

------
https://chatgpt.com/codex/tasks/task_b_68d9cb936c808326802bbb0ac2ff89b5