### PR TITLE
Adjust AppModule imports to existing modules

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -12,25 +12,7 @@ import { AuthModule } from './auth/auth.module';
 
 // Feature modules
 import { EmpresasModule } from './empresas/empresas.module';
-import { UsuariosModule } from './usuarios/usuarios.module';
-import { ClientesModule } from './clientes/clientes.module';
-import { ActivosModule } from './activos/activos.module';
-import { FormulariosModule } from './formularios/formularios.module';
-import { PlanesMantenimientoModule } from './planes-mantenimiento/planes-mantenimiento.module';
 import { CotizacionesModule } from './cotizaciones/cotizaciones.module';
-import { OrdenesTrabajoModule } from './ordenes-trabajo/ordenes-trabajo.module';
-import { EmergenciasModule } from './emergencias/emergencias.module';
-import { DashboardModule } from './dashboard/dashboard.module';
-import { DocumentosModule } from './documentos/documentos.module';
-import { ExternalApiModule } from './external-api/external-api.module';
-import { BitacoraModule } from './bitacora/bitacora.module';
-import { AjustesEmpresaModule } from './ajustes-empresa/ajustes-empresa.module';
-
-// Shared modules
-import { StorageModule } from './shared/storage/storage.module';
-import { MailModule } from './shared/mail/mail.module';
-import { PdfModule } from './shared/pdf/pdf.module';
-import { CronModule } from './shared/cron/cron.module';
 
 @Module({
   imports: [
@@ -78,25 +60,7 @@ import { CronModule } from './shared/cron/cron.module';
 
     // Feature modules
     EmpresasModule,
-    UsuariosModule,
-    ClientesModule,
-    ActivosModule,
-    FormulariosModule,
-    PlanesMantenimientoModule,
     CotizacionesModule,
-    OrdenesTrabajoModule,
-    EmergenciasModule,
-    DashboardModule,
-    DocumentosModule,
-    ExternalApiModule,
-    BitacoraModule,
-    AjustesEmpresaModule,
-
-    // Shared modules
-    StorageModule,
-    MailModule,
-    PdfModule,
-    CronModule,
   ],
 })
 export class AppModule {}


### PR DESCRIPTION
## Summary
- remove imports from AppModule for features and shared modules that are not yet implemented
- keep only the modules that exist in the codebase to avoid missing-module build failures

## Testing
- npm run build *(fails: `nest` binary unavailable because dependencies could not be installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_b_68d9cb053a3c8326b35ec4cabc284870